### PR TITLE
Fix NPE

### DIFF
--- a/src/main/java/com/fleynaro/advancedkits/EventListener.java
+++ b/src/main/java/com/fleynaro/advancedkits/EventListener.java
@@ -26,9 +26,9 @@ class EventListener implements Listener {
             BlockEntity tile = player.getLevel().getBlockEntity(event.getBlock().getLocation());
             if (tile instanceof BlockEntitySign) {
                 String[] text = ((BlockEntitySign) tile).getText();
-                if (TextFormat.clean(text[0]).toLowerCase().equals(this.ak.getConfig().getString("sign-text").toLowerCase())) {
+                if (text[0] != null && TextFormat.clean(text[0]).toLowerCase().equals(this.ak.getConfig().getString("sign-text").toLowerCase())) {
                     event.setCancelled();
-                    if (text[1].isEmpty()) {
+                    if (text[1] == null || text[1].isEmpty()) {
                         event.getPlayer().sendMessage(this.ak.langManager.getTranslation("no-sign-on-kit"));
                         return;
                     }


### PR DESCRIPTION
```
2020-01-29 12:24:19.822 [main] ERROR - Throwing
cn.nukkit.utils.EventException: null
	at cn.nukkit.plugin.MethodEventExecutor.execute(MethodEventExecutor.java:34) ~[nukkit.jar:?]
	at cn.nukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:56) ~[nukkit.jar:?]
	at cn.nukkit.plugin.PluginManager.callEvent(PluginManager.java:546) ~[nukkit.jar:?]
	at cn.nukkit.level.Level.useItemOn(Level.java:2041) ~[nukkit.jar:?]
	at cn.nukkit.level.Level.useItemOn(Level.java:2013) ~[nukkit.jar:?]
	at cn.nukkit.Player.handleDataPacket(Player.java:3041) ~[nukkit.jar:?]
	at java.util.ArrayList.forEach(Unknown Source) [?:1.8.0_202]
	at cn.nukkit.network.Network.processPackets(Network.java:197) [nukkit.jar:?]
	at cn.nukkit.network.Network.processBatch(Network.java:180) [nukkit.jar:?]
	at cn.nukkit.Player.handleDataPacket(Player.java:2092) [nukkit.jar:?]
	at cn.nukkit.network.RakNetInterface.handleEncapsulated(RakNetInterface.java:157) [nukkit.jar:?]
	at cn.nukkit.raknet.server.ServerHandler.handlePacket(ServerHandler.java:132) [nukkit.jar:?]
	at cn.nukkit.network.RakNetInterface.process(RakNetInterface.java:66) [nukkit.jar:?]
	at cn.nukkit.network.Network.processInterfaces(Network.java:83) [nukkit.jar:?]
	at cn.nukkit.Server.tick(Server.java:1125) [nukkit.jar:?]
	at cn.nukkit.Server.tickProcessor(Server.java:904) [nukkit.jar:?]
	at cn.nukkit.Server.start(Server.java:881) [nukkit.jar:?]
	at cn.nukkit.Server.<init>(Server.java:566) [nukkit.jar:?]
	at cn.nukkit.Nukkit.main(Nukkit.java:112) [nukkit.jar:?]
Caused by: java.lang.NullPointerException
	at com.fleynaro.advancedkits.EventListener.onSignClick(EventListener.java:29) ~[?:?]
	at sun.reflect.GeneratedMethodAccessor72.invoke(Unknown Source) ~[?:?]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_202]
	at java.lang.reflect.Method.invoke(Unknown Source) ~[?:1.8.0_202]
	at cn.nukkit.plugin.MethodEventExecutor.execute(MethodEventExecutor.java:29) ~[nukkit.jar:?]
	... 18 more
```